### PR TITLE
Execute tsc with argv0

### DIFF
--- a/src/tsc-shame.ts
+++ b/src/tsc-shame.ts
@@ -136,14 +136,14 @@ async function main() {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tsc-shame-'))
 
     try {
+        const nodePath = process.argv0
         const tscPath = getTscPath()
         console.log()
         console.log('Generating trace with tsc, this may take a while...')
         try {
             execSync(
-                `${tscPath} --incremental false --composite false --generateTrace ${tempDir}`,
+                `${nodePath} ${tscPath} --incremental false --composite false --generateTrace ${tempDir}`,
                 {
-                    shell: 'bash',
                     stdio: 'inherit',
                     // env: { ...process.env, folder: tempDir },
                 },


### PR DESCRIPTION
This adds support for windows, where the 'bash' shell is not available